### PR TITLE
fix(mock): Commit order in MockRepo

### DIFF
--- a/cactuskeeper/test/helpers.py
+++ b/cactuskeeper/test/helpers.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import uuid
 
 import mock
 
@@ -16,17 +17,17 @@ class MockRepo(mock.MagicMock):
 
     def add_commit(self, branch, commit_message, sha=None):
         if sha is None:
-            sha = self.sha_counter
-            self.sha_counter += 1
+            sha = str(uuid.uuid4()).replace("-", "")
 
         commit = mock.Mock(message=commit_message, hexsha=str(sha), parents=[])
+
         # try to mock the parents list
         try:
-            self.commits[branch][-1].parents.append(commit)
+            commit.parents.append(self.commits[branch][0])
         except IndexError:
             pass
 
-        self.commits[branch].append(commit)
+        self.commits[branch].insert(0, commit)
         self.commits_by_sha[sha] = commit
 
     def add_commits(self, branch, commit_messages):
@@ -34,7 +35,7 @@ class MockRepo(mock.MagicMock):
             self.add_commit(branch, message)
 
     def add_existing_commit(self, branch, sha):
-        self.commits[branch].append(self.commits_by_sha[sha])
+        self.commits[branch].insert(0, self.commits_by_sha[sha])
 
     def iter_commits(self, branch, max_count=None):
 

--- a/cactuskeeper/test/test_cli.py
+++ b/cactuskeeper/test/test_cli.py
@@ -34,16 +34,16 @@ class TestCheck:
         """
         repo = MockRepo(branches=["master", "release/v0.9", "release/v0.8"])
 
-        repo.add_commit("release/v0.9", "fix: foo \n foo #456")
-        repo.add_commit("release/v0.9", "fix: bla \n blubi #123")
+        repo.add_commit("release/v0.9", "release: v0.8", sha=0)
         repo.add_commit("release/v0.9", "release: v0.9", sha=1)
-        repo.add_commit("release/v0.8", "release: v0.8", sha=0)
+        repo.add_commit("release/v0.9", "fix: bla \n blubi #123")
+        repo.add_commit("release/v0.9", "fix: foo \n foo #456")
 
         repo.add_existing_commit("release/v0.8", 0)
 
-        repo.add_commit("master", "fix: foo \n foo #456")
         repo.add_existing_commit("master", 0)
         repo.add_existing_commit("master", 1)
+        repo.add_commit("master", "fix: foo \n foo #456")
 
         with mock.patch("cactuskeeper.cli.Repo", return_value=repo):
             runner = CliRunner()
@@ -68,11 +68,11 @@ class TestCheck:
         """
         repo = MockRepo(branches=["master", "release/v0.9"])
 
-        repo.add_commit("release/v0.9", "fix: bla \n blubi #123")
         repo.add_commit("release/v0.9", "release: v0.9", sha=1)
+        repo.add_commit("release/v0.9", "fix: bla \n blubi #123")
 
-        repo.add_commit("master", "fix: bla \n blubi #123")
         repo.add_existing_commit("master", 1)
+        repo.add_commit("master", "fix: bla \n blubi #123")
 
         with mock.patch("cactuskeeper.cli.Repo", return_value=repo):
             runner = CliRunner()
@@ -89,12 +89,12 @@ class TestRelease:
     def setup_mock_repo(self):
         repo = MockRepo(branches=["master"])
 
-        repo.add_commits("master", [
-            "fix: something2 \n #2", "fix: something1 \n #1",
-            "release: v1.2.3 \n info", "fix: something0 \n #0"
-        ])
-
         repo.add_commit("master", "base", sha="12345")
+
+        repo.add_commits("master", [
+            "fix: something0 \n #0", "release: v1.2.3 \n info",
+            "fix: something1 \n #1", "fix: something2 \n #2"
+        ])
 
         with mock.patch("cactuskeeper.cli.Repo", return_value=repo):
             yield

--- a/cactuskeeper/test/test_git.py
+++ b/cactuskeeper/test/test_git.py
@@ -54,8 +54,11 @@ def test_get_latest_release_commit():
     repo = MockRepo(branches=["master"])
     repo.add_commits(
         "master", [
-            "fix: something2 \n #2", "release: v1.2.1",
-            "fix: something1 \n #1", "release: 1.2", "fix: something0 \n #0"
+            "fix: something0 \n #0",
+            "release: 1.2",
+            "fix: something1 \n #1",
+            "release: v1.2.1",
+            "fix: something2 \n #2"
         ]
     )
     release = get_latest_release_commit(repo, "master")
@@ -67,11 +70,12 @@ def test_get_commits_since_commit():
 
     repo = MockRepo(branches=["master"])
 
-    repo.add_commits("master", ["fix: something2 \n #2", "release: v1.2.1"])
-
+    # add some commits from before the base commit
+    repo.add_commits("master", ["first commit", "second commit"])
+    # add the base commit
     repo.add_commit("master", "base_commit", sha="123456")
-
-    repo.add_commits("master", ["another", "yet another"])
+    # add commits after the base commit
+    repo.add_commits("master", ["release: v1.2.1", "fix: something2 \n #2"])
 
     commits = get_commits_since_commit(repo, "master", "123456")
 
@@ -82,11 +86,11 @@ def test_get_commits_since_commit():
 def test_get_bugfixes_relative():
     repo = MockRepo(branches=["release/1.2", "master"])
 
-    repo.add_commit("release/1.2", "fix: important thing \n more info #2")
-    repo.add_commit("release/1.2", "release: v1.2.1")
-    repo.add_commit("release/1.2", "fix: something \n more info #1")
-    repo.add_commit("release/1.2", "release: 1.2", sha=2)
     repo.add_commit("release/1.2", "fix: something \n more info #0", sha=1)
+    repo.add_commit("release/1.2", "release: 1.2", sha=2)
+    repo.add_commit("release/1.2", "fix: something \n more info #1")
+    repo.add_commit("release/1.2", "release: v1.2.1")
+    repo.add_commit("release/1.2", "fix: important thing \n more info #2")
 
     repo.add_existing_commit("master", 1)
     repo.add_existing_commit("master", 2)
@@ -102,8 +106,11 @@ def test_get_bugfixes_absolute():
 
     repo.add_commits(
         "release/1.2", [
-            "fix: something2 \n #2", "release: v1.2.1",
-            "fix: something1 \n #1", "release: 1.2", "fix: something0 \n #0"
+            "fix: something0 \n #0"
+            "release: 1.2",
+            "fix: something1 \n #1",
+            "release: v1.2.1",
+            "fix: something2 \n #2",
         ]
     )
     result = get_bugfixes_for_branch(repo, "release/1.2")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [tool:pytest]
 minversion = 3.0
+timeout = 5
 addopts =
     --cov=cactuskeeper
     --cov-report=term-missing

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest~=3.0
 pytest-cov
+pytest-timeout
 mock


### PR DESCRIPTION
Commits are now ordered in chronological
order. I.e. add older commits first, like
in a real repo.

Fix #7