### PR TITLE
feat(git): Add next_version calculation

### DIFF
--- a/cactuskeeper/git.py
+++ b/cactuskeeper/git.py
@@ -25,6 +25,38 @@ class CommitMetadata:
             if m.group("version"):
                 self.version = m.group("version")
 
+    def next_version(self, step="bugfix"):
+        """
+            Calculates the next version for release commits.
+
+            :param step:
+                The level on which the next version should be created.
+                Can be "major", "minor" or "bugfix"
+
+            :return:
+                The next version as a string or None if the commit is not a release commit.
+        """
+        if not self.version:
+            return None
+
+        current_version = StrictVersion(self.version)
+
+        major = current_version.version[0]
+        minor = current_version.version[1]
+        bugfix = current_version.version[2]
+
+        if step == "major":
+            major = major + 1
+            minor = 0
+            bugfix = 0
+        if step == "minor":
+            minor = minor + 1
+            bugfix = 0
+        if step == "bugfix":
+            bugfix = bugfix + 1
+
+        return ".".join(map(lambda x: str(x), [major, minor, bugfix]))
+
 
 def get_release_branches(repo, release_branch_re=RELEASE_BRANCHES):
     release_branches = []

--- a/cactuskeeper/test/test_git.py
+++ b/cactuskeeper/test/test_git.py
@@ -2,9 +2,11 @@
 from distutils.version import StrictVersion
 import re
 
+from mock import Mock
 import pytest
 
 from cactuskeeper.git import (
+    CommitMetadata,
     get_bugfixes_for_branch,
     get_commits_since_commit,
     get_latest_release_commit,
@@ -122,3 +124,24 @@ def test_get_bugfixes_absolute():
     result = get_bugfixes_for_branch(repo, "release/1.2")
 
     assert set(result.keys()) == set(["#2", "#1", "#0", "_list"])
+
+
+def test_commit_get_next_version():
+    repo = MockRepo(branches=["master"])
+    repo.add_commits("master", ["release: v1.2.0"])
+
+    commit = get_latest_release_commit(repo, "master")
+
+    assert "1.2.0" == commit.version
+    assert "1.2.1" == commit.next_version()
+    assert "1.2.1" == commit.next_version(step="bugfix")
+    assert "1.3.0" == commit.next_version(step="minor")
+    assert "2.0.0" == commit.next_version(step="major")
+
+
+def test_commit_get_next_version_no_release():
+    """ next_version for non-release commits returns None """
+
+    commit = CommitMetadata(Mock(message="Something, but surely no release"))
+
+    assert commit.next_version() is None


### PR DESCRIPTION
CommitMetadata objects for release commits
can now calculate the next version.

Close #13