### PR TITLE
fix(check): Present missing fixes in deterministic order

### DIFF
--- a/cactuskeeper/cli.py
+++ b/cactuskeeper/cli.py
@@ -54,12 +54,12 @@ def check(context):
             clean = False
             click.echo(
                 "\nBranch '{other}' contains the following "
-                "fixes not present in '{base}'".format(
+                "fixes not present in '{base}' (newest first)".format(
                     base=current_branch, other=click.style(str(branch["branch"]), fg="yellow")
                 )
             )
-
-            for issue_number in missing_fixes:
+            fixes_keys = list(fixes.keys())
+            for issue_number in sorted(missing_fixes, key=lambda x: fixes_keys.index(x)):
                 commit = fixes[issue_number]
                 click.echo("\t({hexsha})\t{issue}\t{shortlog}".format(
                     shortlog=commit.shortlog, issue=commit.issue, hexsha=commit.object.hexsha[:11]

--- a/cactuskeeper/git.py
+++ b/cactuskeeper/git.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from distutils.version import StrictVersion
 from itertools import takewhile
 import re
@@ -117,15 +118,12 @@ def get_bugfixes_for_branch(repo, branch, base_branch=None):
 
     commits = get_commits_while(repo, branch, test)
 
-    result = {
-        "_list": []
-    }
+    result = OrderedDict()
     for commit in commits:
         if commit.version:
             continue
         if commit.issue:
             result[commit.issue] = commit
-            result["_list"].append(commit)
     return result
 
 

--- a/cactuskeeper/test/test_git.py
+++ b/cactuskeeper/test/test_git.py
@@ -117,7 +117,7 @@ def test_get_bugfixes_absolute():
     )
     result = get_bugfixes_for_branch(repo, "release/1.2")
 
-    assert set(result.keys()) == set(["#2", "#1", "#0", "_list"])
+    assert set(result.keys()) == set(["#2", "#1", "#0"])
 
 
 def test_commit_get_next_version():


### PR DESCRIPTION
  Missing fixes are now presented in the order they appear on
  the other branch with newset commits first.

  Fix #24